### PR TITLE
Support file fields in schemas

### DIFF
--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from pydantic import IPvAnyAddress, Json
 from pydantic.fields import FieldInfo, Required, Undefined
 
+
 INT_TYPES = [
     "AutoField",
     "BigAutoField",
@@ -24,6 +25,7 @@ STR_TYPES = [
     "SlugField",
     "TextField",
     "FilePathField",
+    "FileField",
 ]
 
 

--- a/djantic/main.py
+++ b/djantic/main.py
@@ -22,16 +22,14 @@ class ModelSchemaJSONEncoder(DjangoJSONEncoder):
     def default(self, obj):  # pragma: nocover
         if isinstance(obj, Promise):
             return force_str(obj)
+
         return super().default(obj)
 
 
 class ModelSchemaMetaclass(ModelMetaclass):
     @no_type_check
     def __new__(
-        mcs,
-        name: str,
-        bases: tuple,
-        namespace: dict,
+        mcs, name: str, bases: tuple, namespace: dict,
     ):
         cls = super().__new__(mcs, name, bases, namespace)
         for base in reversed(bases):
@@ -242,7 +240,11 @@ class ModelSchema(BaseModel, metaclass=ModelSchemaMetaclass):
                     obj_data[field.name] = related_obj_data
 
                 else:
-                    obj_data[field.name] = field.value_from_object(instance)
+                    # Handle field and image fields.
+                    field_data = field.value_from_object(instance)
+                    if hasattr(field_data, "field"):
+                        field_data = str(field_data.field.value_from_object(instance))
+                    obj_data[field.name] = field_data
 
             model_schema = cls._get_object_model(obj_data)
 

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,46 @@
+from tempfile import NamedTemporaryFile
+
+import pytest
+
+from testapp.models import Attachment
+from djantic import ModelSchema
+
+
+@pytest.mark.django_db
+def test_image_field_schema():
+    class AttachmentSchema(ModelSchema):
+        class Config:
+            model = Attachment
+
+    image_file = NamedTemporaryFile(suffix=".jpg")
+    attachment = Attachment.objects.create(
+        description="My image upload", image=image_file.name,
+    )
+
+    assert AttachmentSchema.schema() == {
+        "title": "AttachmentSchema",
+        "description": "Attachment(id, description, image)",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "description": "id", "type": "integer"},
+            "description": {
+                "title": "Description",
+                "description": "description",
+                "maxLength": 255,
+                "type": "string",
+            },
+            "image": {
+                "title": "Image",
+                "description": "image",
+                "maxLength": 100,
+                "type": "string",
+            },
+        },
+        "required": ["description"],
+    }
+
+    assert AttachmentSchema.from_django(attachment).dict() == {
+        "id": attachment.id,
+        "description": attachment.description,
+        "image": attachment.image.name,
+    }

--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 
+
 from testapp.models import User, Profile, Thread, Message, Tagged, Bookmark
 
 from djantic import ModelSchema
@@ -29,7 +30,7 @@ def test_get_instance():
 def test_get_instance_with_generic_foreign_key():
 
     bookmark = Bookmark.objects.create(url="https://www.djangoproject.com/")
-    Tagged.objects.create(content_object=bookmark, slug="django")
+    tagged = Tagged.objects.create(content_object=bookmark, slug="django")
 
     class TaggedSchema(ModelSchema):
         class Config:
@@ -46,7 +47,7 @@ def test_get_instance_with_generic_foreign_key():
 
     assert bookmark_with_tagged_schema.dict() == {
         "id": 1,
-        "tags": [{"content_type": 20, "id": 1, "object_id": 1, "slug": "django"}],
+        "tags": [{"content_type": 20, "id": 1, "object_id": 1, "slug": "django",}],
         "url": "https://www.djangoproject.com/",
     }
 

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -1,4 +1,5 @@
 import uuid
+import os.path
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -189,3 +190,14 @@ class Tagged(models.Model):
 class Bookmark(models.Model):
     url = models.URLField()
     tags = GenericRelation(Tagged)
+
+
+def upload_image_handler(instance, filename):
+    base_name, ext = os.path.splitext(filename)
+
+    return f"{base_name}{uuid.uuid4()}{ext}"
+
+
+class Attachment(models.Model):
+    description = models.CharField(max_length=255)
+    image = models.ImageField(blank=True, null=True, upload_to=upload_image_handler)


### PR DESCRIPTION
Adds `FileField` to the string types and casts to strings in the export from the field attribute. Probably should include a way to customise the export format using schemas, but should be good for now to resolve https://github.com/jordaneremieff/djantic/issues/17#issuecomment-853999450.