### PR TITLE
Add tests for TextChoices and IntegerChoices and change default schema representation

### DIFF
--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -91,6 +91,8 @@ def ModelSchemaField(field: Any) -> tuple:
                 enum_choices,
                 module=__name__,
             )
+            if field.has_default() and isinstance(field.default, Enum):
+                default = field.default.value
         else:
             internal_type = field.get_internal_type()
             if internal_type in STR_TYPES:
@@ -118,7 +120,7 @@ def ModelSchemaField(field: Any) -> tuple:
         blank = field_options.pop("blank", False)
         null = field_options.pop("null", False)
 
-        if field.has_default():
+        if default is Required and field.has_default():
             if callable(field.default):
                 default_factory = field.default
                 default = Undefined

--- a/djantic/main.py
+++ b/djantic/main.py
@@ -49,6 +49,7 @@ class ModelSchemaMetaclass(ModelMetaclass):
                     )
 
                 annotations = namespace.get("__annotations__", {})
+
                 try:
                     fields = config.model._meta.get_fields()
                 except AttributeError as exc:

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -201,3 +201,23 @@ def upload_image_handler(instance, filename):
 class Attachment(models.Model):
     description = models.CharField(max_length=255)
     image = models.ImageField(blank=True, null=True, upload_to=upload_image_handler)
+
+
+class FoodChoices(models.TextChoices):
+    BANANA = "ba", "A delicious yellow Banana"
+    APPLE = "ap", "A delicious red Apple"
+
+
+class GroupChoices(models.IntegerChoices):
+    GROUP_1 = 1, "First group"
+    GROUP_2 = 2, "Second group"
+
+
+class Preference(models.Model):
+    name = models.CharField(max_length=128)
+    preferred_food = models.CharField(
+        max_length=2, choices=FoodChoices.choices, default=FoodChoices.BANANA
+    )
+    preferred_group = models.IntegerField(
+        choices=GroupChoices.choices, default=GroupChoices.GROUP_1
+    )


### PR DESCRIPTION
This includes tests for the `TextChoices` and `IntegerChoices` classes in Django and converts any enum type defaults to values in schema generation.

Prompted by https://github.com/jordaneremieff/djantic/issues/27, but I was unable to reproduce - this PR just adds additional coverage and the schema change.