### PR TITLE
Set default and log warning for unhandled field types

### DIFF
--- a/djantic/fields.py
+++ b/djantic/fields.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Dict, List, Union
 from decimal import Decimal
 from datetime import date, time, datetime, timedelta
@@ -6,6 +7,8 @@ from uuid import UUID
 
 from pydantic import IPvAnyAddress, Json
 from pydantic.fields import FieldInfo, Required, Undefined
+
+logger = logging.getLogger("djantic")
 
 
 INT_TYPES = [
@@ -65,6 +68,7 @@ def ModelSchemaField(field: Any) -> tuple:
     description = None
     title = None
     max_length = None
+    python_type = None
 
     if field.is_relation:
         if not field.related_model:
@@ -114,6 +118,12 @@ def ModelSchemaField(field: Any) -> tuple:
                         if _internal_type in FIELD_TYPES:
                             python_type = FIELD_TYPES[_internal_type]
                             break
+
+        if python_type is None:
+            logger.warning(
+                "%s is currently unhandled, defaulting to str.", field.__class__
+            )
+            python_type = str
 
         deconstructed = field.deconstruct()
         field_options = deconstructed[3] or {}

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,49 @@
 import pytest
 
-from testapp.models import Record, Configuration, Preference, FoodChoices, GroupChoices
+from testapp.models import (
+    Record,
+    Configuration,
+    Preference,
+    FoodChoices,
+    GroupChoices,
+    Searchable,
+)
 from djantic import ModelSchema
+
+
+@pytest.mark.django_db
+def test_unhandled_field_type():
+    class SearchableSchema(ModelSchema):
+        class Config:
+            model = Searchable
+
+    assert SearchableSchema.schema() == {
+        "title": "SearchableSchema",
+        "description": "Searchable(id, title, search_vector)",
+        "type": "object",
+        "properties": {
+            "id": {"title": "Id", "description": "id", "type": "integer"},
+            "title": {
+                "title": "Title",
+                "description": "title",
+                "maxLength": 255,
+                "type": "string",
+            },
+            "search_vector": {
+                "title": "Search Vector",
+                "description": "search_vector",
+                "type": "string",
+            },
+        },
+        "required": ["title"],
+    }
+
+    searchable = Searchable.objects.create(title="My content")
+    assert SearchableSchema.from_django(searchable).dict() == {
+        "id": 1,
+        "title": "My content",
+        "search_vector": None,
+    }
 
 
 @pytest.mark.django_db

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -15,17 +15,6 @@ from django.utils import timezone
 from .fields import ListField, NotNullRestrictedCharField
 
 
-class Searchable(models.Model):
-    title = models.CharField(max_length=255)
-    search_vector = SearchVectorField(null=True)
-
-    def __str__(self):
-        return self.title
-
-    class Meta:
-        indexes = [GinIndex(fields=["search_vector"], name="search_vector_idx")]
-
-
 class Thread(models.Model):
     """
     A thread of messages.
@@ -236,3 +225,14 @@ class Preference(models.Model):
     preferred_group = models.IntegerField(
         choices=GroupChoices.choices, default=GroupChoices.GROUP_1
     )
+
+
+class Searchable(models.Model):
+    title = models.CharField(max_length=255)
+    search_vector = SearchVectorField(null=True)
+
+    def __str__(self):
+        return self.title
+
+    class Meta:
+        indexes = [GinIndex(fields=["search_vector"], name="search_vector_idx")]

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -7,8 +7,23 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.utils.text import slugify
 from django.contrib.postgres.fields import JSONField
+from django.contrib.postgres.indexes import GinIndex
+from django.contrib.postgres.search import SearchVectorField
 from django.utils.translation import gettext_lazy as _
+from django.utils import timezone
+
 from .fields import ListField, NotNullRestrictedCharField
+
+
+class Searchable(models.Model):
+    title = models.CharField(max_length=255)
+    search_vector = SearchVectorField(null=True)
+
+    def __str__(self):
+        return self.title
+
+    class Meta:
+        indexes = [GinIndex(fields=["search_vector"], name="search_vector_idx")]
 
 
 class Thread(models.Model):


### PR DESCRIPTION
Refs https://github.com/jordaneremieff/djantic/issues/31

The python type for `SearchVectorField` is not explicitly supported and also cannot be determined automatically. This will log a warning and default to string in these cases rather than raising an unhandled exception when the type value is not defined.