### PR TITLE
Support reverse m2m in exports

### DIFF
--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -235,3 +235,18 @@ class Searchable(models.Model):
 
     class Meta:
         indexes = [GinIndex(fields=["search_vector"], name="search_vector_idx")]
+
+
+class ExtendedModel(models.Model):
+    name = models.CharField(max_length=128)
+
+    class Meta:
+        abstract = True
+
+
+class Expert(ExtendedModel):
+    cases = models.ManyToManyField("Case", related_name="related_experts")
+
+
+class Case(ExtendedModel):
+    details = models.TextField()


### PR DESCRIPTION
Refs https://github.com/jordaneremieff/djantic/pull/33

This will add support for reverse m2m relations in `from_django` data exports.

I probably need to cleanup the export logic generally at some point to make it less confusing and refactor the tests to group things by field relation type.