### PR TITLE
Fix custom field support and add include_from_annotations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,3 +223,35 @@ print(OrderUserSchema.from_orm(user).json(ident=4))
     "email": ""
 }
 ```
+
+
+### Include from annotations
+
+By default, a Schema without Config.include or Config.exclude defined will include all fields of the Config.model class.
+
+If you want to limit included fields to the annotations of the Schema without defining Config.include, use `Config.include = "__annotations__"`. 
+
+
+```python
+class ProfileSchema(ModelSchema):
+        website: str
+
+        class Config:
+            model = Profile
+            include = "__annotations__"
+
+    assert ProfileSchema.schema() == {
+        "title": "ProfileSchema",
+        "description": "A user's profile.",
+        "type": "object",
+        "properties": {
+            "website": {
+                "title": "Website",
+                "type": "string"
+            }
+        },
+        "required": [
+            "website"
+        ]
+    }
+```

--- a/tests/test_multiple_level_relations.py
+++ b/tests/test_multiple_level_relations.py
@@ -1,8 +1,9 @@
 
 from decimal import Decimal
-from typing import List
+from typing import List, Optional
 
 import pytest
+from pydantic import validator
 from testapp.order import Order, OrderItem, OrderItemDetail, OrderUser, OrderUserFactory, OrderUserProfile
 
 from djantic import ModelSchema
@@ -34,9 +35,23 @@ def test_multiple_level_relations():
     class OrderUserSchema(ModelSchema):
         orders: List[OrderSchema]
         profile: OrderUserProfileSchema
+        user_cache: Optional[dict]
 
         class Config:
             model = OrderUser
+            include = ('id',
+                       'first_name',
+                       'last_name',
+                       'email',
+                       'profile',
+                       'orders',
+                       'user_cache')
+
+        @validator('user_cache', pre=True, always=True)
+        def get_user_cache(cls, _):
+            return {
+                'has_order': True
+            }
 
     user = OrderUserFactory.create()
 
@@ -45,6 +60,7 @@ def test_multiple_level_relations():
         'first_name': '',
         'last_name': None,
         'email': '',
+        'user_cache': {'has_order': True},
         'profile': {
             'id': 1,
             'address': '',
@@ -195,6 +211,10 @@ def test_multiple_level_relations():
                 "description": "email",
                 "maxLength": 254,
                 "type": "string"
+            },
+            "user_cache": {
+                "title": "User Cache",
+                "type": "object"
             }
         },
         "required": [

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -380,3 +380,32 @@ def test_json():
   ]
 }"""
     assert ConfigurationSchema.schema_json(indent=2) == expected
+
+
+@pytest.mark.django_db
+def test_include_from_annotations():
+    """
+    Test include="__annotations__" config.
+    """
+
+    class ProfileSchema(ModelSchema):
+        website: str
+
+        class Config:
+            model = Profile
+            include = "__annotations__"
+
+    assert ProfileSchema.schema() == {
+        "title": "ProfileSchema",
+        "description": "A user's profile.",
+        "type": "object",
+        "properties": {
+            "website": {
+                "title": "Website",
+                "type": "string"
+            }
+        },
+        "required": [
+            "website"
+        ]
+    }


### PR DESCRIPTION
Hi,

This PR will:
- Add support to `include_from_annotations` as shown in README and `test_include_from_annotations`.
- Fix the error shown in `test_multiple_level_relations` where a custom field (`user_cache` in this example) is present in the Schema.

Thank you.